### PR TITLE
Fixed the loading of mime.types files from the classpath.

### DIFF
--- a/src/main/java/org/clapper/util/misc/MIMETypeUtil.java
+++ b/src/main/java/org/clapper/util/misc/MIMETypeUtil.java
@@ -92,7 +92,7 @@ import java.util.ResourceBundle;
  * syntax:</p>
  *
  * <pre>
- * # The format is <mime type> <space separated file extensions>
+ * # The format is &lt;mime type&gt; &lt;space separated file extensions&gt;
  * # Comments begin with a '#'
  *
  * text/plain             txt text TXT
@@ -449,7 +449,8 @@ public class MIMETypeUtil
         // Now, check every directory in the classpath.
 
         String   pathSep = System.getProperty ("path.separator");
-        String[] pathComponents = TextUtil.split (pathSep);
+        String   classPath = System.getProperty ("java.class.path");
+        String[] pathComponents = TextUtil.split (classPath, pathSep);
         int      i;
 
         for (i = 0; i < pathComponents.length; i++)


### PR DESCRIPTION
As written, the code would attempt to load the mime.types file from a directory named by the path separator, without actually looking at the class path at all.

This changes the code to use the path separator to split the class path, so that it tries to load the file from the class path entries like the documentation says it does.

(While I don't think it's actually necessary for something this small: I hereby state that this patch was written by me, and I am licensing it to you under a BSD license.)
