### PR TITLE
Fix possible NullPointerExceptions

### DIFF
--- a/src/main/java/org/clapper/util/classutil/ClassFinder.java
+++ b/src/main/java/org/clapper/util/classutil/ClassFinder.java
@@ -474,7 +474,7 @@ public class ClassFinder
         {
             try
             {
-                jar.close();
+                if (jar != null) jar.close();
             }
 
             catch (IOException ex)
@@ -508,7 +508,7 @@ public class ClassFinder
         {
             try
             {
-                zip.close();
+                if (zip != null) zip.close();
             }
 
             catch (IOException ex)


### PR DESCRIPTION
If creation of the ZipFile and JarFile instances fails, those variables will be null and the finally block will throw a NPE. This patch adds a check to ensure null resources aren't closed.
