### PR TITLE
Add support for JDK 8 language features - upgrade to ASM v6

### DIFF
--- a/src/main/java/org/clapper/util/classutil/ClassInfo.java
+++ b/src/main/java/org/clapper/util/classutil/ClassInfo.java
@@ -12,8 +12,8 @@ import java.util.Set;
 
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.commons.EmptyVisitor;
 import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 
 /**
@@ -25,7 +25,7 @@ import org.objectweb.asm.Opcodes;
  * <a href="http://asm.objectweb.org"><i>asm.objectweb.org</i></a> for
  * details on ASM.</p>
  */
-public class ClassInfo extends EmptyVisitor
+public class ClassInfo extends ClassVisitor
 {
     static int ASM_CR_ACCEPT_CRITERIA = 0;
 
@@ -54,6 +54,7 @@ public class ClassInfo extends EmptyVisitor
      */
     public ClassInfo(File classFile) throws ClassUtilException
     {
+        super(Opcodes.ASM5);
         try
         {
             ClassReader cr = new ClassReader(new FileInputStream(classFile));
@@ -79,6 +80,7 @@ public class ClassInfo extends EmptyVisitor
      */
     public ClassInfo(InputStream is) throws ClassUtilException
     {
+        super(Opcodes.ASM5);
         try
         {
             ClassReader cr = new ClassReader(is);
@@ -111,6 +113,7 @@ public class ClassInfo extends EmptyVisitor
               int      asmAccessMask,
               File     location)
     {
+        super(Opcodes.ASM5);
         setClassFields(name, superClassName, interfaces, asmAccessMask, location);
     }
 

--- a/src/main/java/org/clapper/util/classutil/ClassInfoClassVisitor.java
+++ b/src/main/java/org/clapper/util/classutil/ClassInfoClassVisitor.java
@@ -1,8 +1,9 @@
 package org.clapper.util.classutil;
 
+import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.commons.EmptyVisitor;
+import org.objectweb.asm.Opcodes;
 
 import java.io.File;
 import java.util.Map;
@@ -18,7 +19,7 @@ import java.util.Map;
  *
  * @see ClassFinder
  */
-class ClassInfoClassVisitor extends EmptyVisitor
+class ClassInfoClassVisitor extends ClassVisitor
 {
     /*----------------------------------------------------------------------*\
                             Private Data Items
@@ -44,6 +45,7 @@ class ClassInfoClassVisitor extends EmptyVisitor
      */
     ClassInfoClassVisitor(Map<String,ClassInfo> foundClasses, File location)
     {
+        super(Opcodes.ASM5);
         this.foundClasses = foundClasses;
         this.location = location;
     }


### PR DESCRIPTION
ASM 3 can give runtime errors (ArrayIndexOutOfBoundsException) which I think is because I started using lambda functions in a class that was previously being read just fine.  The effect was that `ClassFinder` will silently stop finding the class (silently because I didn't know about `org.clapper.util.logging.Logger.enableLogging()` at the time :) )

Upgrading to ASM 6 fixed the problem, but needed these minor changes.  I don't know SBT so I have not been able to run the unit tests, nor have I been able to modify the `build.sbt` file to pull in the 6.0 of asm, but hope this PR is helpful nonetheless.